### PR TITLE
Prefix tour target with current page

### DIFF
--- a/src/main/js/controller/guidedTourController.js
+++ b/src/main/js/controller/guidedTourController.js
@@ -48,7 +48,7 @@ var GuidedTourController = (function() {
                 Pages.navigateToChart();
             }
         }, {
-            anchor: '[data-target="#map"]',
+            anchor: '.swc-page-current [data-target="#map"]',
             title: _('guide.step2.header'),
             text: _('guide.step2.text'),
             previous: false,
@@ -144,7 +144,7 @@ var GuidedTourController = (function() {
             initStep: function() {
             }
         }, {
-            anchor: '[data-target="#favorites"]',
+            anchor: '.swc-page-current [data-target="#favorites"]',
             title: _('guide.step13.header'),
             text: _('guide.step13.text'),
             previous: false,


### PR DESCRIPTION
The tour is broken if you add an additional page, as the popup is shown on the first navigation button, which may be on the added page and not on the current one...
